### PR TITLE
Ensure version 3.9.1 of Python is specified everywhere it needs to be

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ pip-selfcheck.json
 learningenv
 .secrets
 socialaccount.json
+superuser.json
 db.local.json
 debug.log
 .ubuntusetup

--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ wheel = "*"
 openai = "*"
 
 [requires]
-python_version = "*"
+python_version = "3.9.1"
 
 [scripts]
 migrate = "python3 manage.py migrate"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Do not do step 5... only steps 1-4.
 
 Once you are done, you will be working in an Ubuntu terminal during all setup and developing on the API.
 
-### If WSL Already Exists
+### If WSL and Postgres Already Exists
 
-If you already have Postgres installed in Ubuntu, then you need to uninstall it and kill the existing cluser.
+If you already have Postgres installed in Ubuntu, then you need to uninstall it and kill the existing cluster.
 
 ```sh
 sudo apt remove postgresql

--- a/setup_mac_data.sh
+++ b/setup_mac_data.sh
@@ -73,6 +73,8 @@ function generateSuperuserFixture() {
 }
 
 function initializeProject() {
+    pipenv --python 3.9.1
+
     # Install project requirements
     pipenv install
 

--- a/setup_mac_python.sh
+++ b/setup_mac_python.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYTHON_VERSION=3.9
+PYTHON_VERSION=3.9.1
 
 function installPyenv() {
     if [ $(brew list | grep -c pyenv) != 1 ]; then

--- a/setup_ubuntu_local.sh
+++ b/setup_ubuntu_local.sh
@@ -14,6 +14,8 @@ if ! command -v psql &>/dev/null; then
     sudo apt install postgresql postgresql-contrib -y
 fi
 
+
+# Check if systemd is running by examining the presence of systemd's runtime directory
 echo "Restarting Postgresql"
 if [ -d /run/systemd/system ]; then
     echo "Systemd is enabled"
@@ -22,7 +24,6 @@ else
     echo "Systemd is not enabled"
     sudo service postgresql start >> /dev/null
 fi
-
 
 #####
 # Get Postgres version


### PR DESCRIPTION
In both Ubuntu and Mac bash script, it was discovered that a different Python version was being ysed by `pipenv` when setting up the virtual environment. Both have been updated with the following command.

```bash
pipenv --python 3.9.1
```

Additionally, the correct version is now in the **Pipfile** and as the value of **PYTHON_VERSION** variable in the bash script.